### PR TITLE
feat(directive): 支持背景图优化

### DIFF
--- a/docs/directive.md
+++ b/docs/directive.md
@@ -1,13 +1,11 @@
-使用指令 `v-img` 使得 background-image 可以获得与 v-img 本身一样的功能：
+使用指令 `v-img` 可以对 background-image 进行图片优化。
 
-- 图片地址依然使用 `src` 参数，如 `v-img="{src: ''}"`
-- 与 v-img 一样的参数设置，如 `v-img="{provider: 'qiniu'}"`
+与 v-img 一样的参数设置，如 `v-img="{src: '', provider: 'qiniu'}"`
 
 
-use `v-img` directive, let background-image's feature the same as v-img by itself
+use `v-img` directive, can let background-image to use webp。
 
-- image source just use `src` attribute likes `v-img="{src: ''}"`
-- all from `v-img` parameters likes `v-img="{provider: 'qiniu'}"`
+`v-img="{src: '', provider: 'qiniu'}"`
 
 ```vue
 <template>

--- a/docs/directive.md
+++ b/docs/directive.md
@@ -4,6 +4,11 @@
 - 与 v-img 一样的参数设置，如 `v-img:background="{provider: 'qiniu'}"`
 
 
+use `v-img:background` directive, let background-image's feature the same as v-img by itself
+
+- image source just use `src` attribute
+- all from `v-img` parameters likes `v-img:background="{provider: 'qiniu'}"`
+
 ```vue
 <template>
   <div v-img:background :src="src" style="width:200px;height:200px" />

--- a/docs/directive.md
+++ b/docs/directive.md
@@ -2,7 +2,6 @@
 
 - 图片地址依然使用 `src` 参数
 - 与 v-img 一样的参数设置，如 `v-img:background="{provider: 'qiniu'}"`
-- 支持 `background` 参数，如 `v-img:background="{size: 'cover'}"`
 
 
 ```vue

--- a/docs/directive.md
+++ b/docs/directive.md
@@ -1,0 +1,22 @@
+使用指令 `v-img:background` 使得 background-image 可以获得与 v-img 本身一样的功能：
+
+- 图片地址依然使用 `src` 参数
+- 与 v-img 一样的参数设置，如 `v-img:background="{provider: 'qiniu'}"`
+- 支持 `background` 参数，如 `v-img:background="{size: 'cover'}"`
+
+
+```vue
+<template>
+  <div v-img:background :src="src" style="width:200px;height:200px" />
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      src: 'http://image-demo.oss-cn-hangzhou.aliyuncs.com/panda.png'
+    }
+  }
+}
+</script>
+```

--- a/docs/directive.md
+++ b/docs/directive.md
@@ -1,17 +1,17 @@
-使用指令 `v-img:background` 使得 background-image 可以获得与 v-img 本身一样的功能：
+使用指令 `v-img` 使得 background-image 可以获得与 v-img 本身一样的功能：
 
-- 图片地址依然使用 `src` 参数
-- 与 v-img 一样的参数设置，如 `v-img:background="{provider: 'qiniu'}"`
+- 图片地址依然使用 `src` 参数，如 `v-img="{src: ''}"`
+- 与 v-img 一样的参数设置，如 `v-img="{provider: 'qiniu'}"`
 
 
-use `v-img:background` directive, let background-image's feature the same as v-img by itself
+use `v-img` directive, let background-image's feature the same as v-img by itself
 
-- image source just use `src` attribute
-- all from `v-img` parameters likes `v-img:background="{provider: 'qiniu'}"`
+- image source just use `src` attribute likes `v-img="{src: ''}"`
+- all from `v-img` parameters likes `v-img="{provider: 'qiniu'}"`
 
 ```vue
 <template>
-  <div v-img:background :src="src" style="width:200px;height:200px" />
+  <div v-img="{src}" style="width:200px;height:200px" />
 </template>
 
 <script>

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,47 @@
+import 'lazysizes/plugins/bgset/ls.bgset'
+import providerConf from './provider-config'
+
+const isBg = arg => arg === 'background'
+const isSupportWebp = JSON.parse(localStorage.getItem('isSupportWebp')) || false
+
+export default {
+  init(el, {arg, value = {}}) {
+    if (!isBg(arg)) {
+      return
+    }
+    const {provider = 'alibaba', extraQuery, ...other} = value
+    const backgroundArgs = Object.keys(other).filter(
+      item => `background${item[0].toUpperCase() + item.slice(1)}` in el.style
+    )
+    const src = providerConf[provider].getSrc({
+      src: el.getAttribute('src'),
+      isSupportWebp,
+      extraQuery
+    })
+
+    el.style.backgroundSize = 'cover'
+    if (backgroundArgs.length) {
+      backgroundArgs.forEach(arg => {
+        const key = arg[0].toUpperCase() + arg.slice(1)
+        el.style[`background${key}`] = other[arg]
+      })
+    }
+
+    el.classList.add('lazyload')
+    el.setAttribute('data-bgset', src)
+  },
+
+  update(el, {arg, value = {}}) {
+    if (!isBg(arg)) {
+      return
+    }
+    const {provider = 'alibaba', extraQuery} = value
+    const src = providerConf[provider].getSrc({
+      src: el.getAttribute('src'),
+      isSupportWebp,
+      extraQuery
+    })
+
+    el.style.backgroundImage = `url(${src})`
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -2,31 +2,27 @@ import 'lazysizes/plugins/bgset/ls.bgset'
 import providerConf from './provider-config'
 
 const isBg = arg => arg === 'background'
-const isSupportWebp = JSON.parse(localStorage.getItem('isSupportWebp')) || false
+
+function getSrc(el, config) {
+  const isSupportWebp =
+    JSON.parse(localStorage.getItem('isSupportWebp')) || false
+  const {provider = 'alibaba', extraQuery} = config
+  const src = providerConf[provider].getSrc({
+    src: el.getAttribute('src'),
+    isSupportWebp,
+    extraQuery
+  })
+
+  return src
+}
 
 export default {
   init(el, {arg, value = {}}) {
     if (!isBg(arg)) {
       return
     }
-    const {provider = 'alibaba', extraQuery, ...other} = value
-    const backgroundArgs = Object.keys(other).filter(
-      item => `background${item[0].toUpperCase() + item.slice(1)}` in el.style
-    )
-    const src = providerConf[provider].getSrc({
-      src: el.getAttribute('src'),
-      isSupportWebp,
-      extraQuery
-    })
 
-    el.style.backgroundSize = 'cover'
-    if (backgroundArgs.length) {
-      backgroundArgs.forEach(arg => {
-        const key = arg[0].toUpperCase() + arg.slice(1)
-        el.style[`background${key}`] = other[arg]
-      })
-    }
-
+    const src = getSrc(el, value)
     el.classList.add('lazyload')
     el.setAttribute('data-bgset', src)
   },
@@ -35,13 +31,8 @@ export default {
     if (!isBg(arg)) {
       return
     }
-    const {provider = 'alibaba', extraQuery} = value
-    const src = providerConf[provider].getSrc({
-      src: el.getAttribute('src'),
-      isSupportWebp,
-      extraQuery
-    })
 
+    const src = getSrc(el, value)
     el.style.backgroundImage = `url(${src})`
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1,38 +1,30 @@
 import 'lazysizes/plugins/bgset/ls.bgset'
 import providerConf from './provider-config'
 
-const isBg = arg => arg === 'background'
-
-function getSrc(el, config) {
+function getSrc(config) {
   const isSupportWebp =
     JSON.parse(localStorage.getItem('isSupportWebp')) || false
-  const {provider = 'alibaba', extraQuery} = config
-  const src = providerConf[provider].getSrc({
-    src: el.getAttribute('src'),
+  const {provider = 'alibaba', extraQuery, src} = config
+  if (!src) {
+    return
+  }
+
+  return providerConf[provider].getSrc({
+    src,
     isSupportWebp,
     extraQuery
   })
-
-  return src
 }
 
 export default {
-  init(el, {arg, value = {}}) {
-    if (!isBg(arg)) {
-      return
-    }
-
-    const src = getSrc(el, value)
+  init(el, {value = {}}) {
+    const src = getSrc(value)
     el.classList.add('lazyload')
     el.setAttribute('data-bgset', src)
   },
 
-  update(el, {arg, value = {}}) {
-    if (!isBg(arg)) {
-      return
-    }
-
-    const src = getSrc(el, value)
+  update(el, {value = {}}) {
+    const src = getSrc(value)
     el.style.backgroundImage = `url(${src})`
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // Import vue component
 import Component from './v-img.vue'
+import background from './background'
 
 // `Vue.use` automatically prevents you from using
 // the same plugin more than once,
@@ -7,6 +8,11 @@ import Component from './v-img.vue'
 // will install the plugin only once
 Component.install = Vue => {
   Vue.component(Component.name, Component)
+
+  Vue.directive('img', {
+    inserted: background.init,
+    update: background.update
+  })
 }
 
 // To auto-install when vue is found

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -38,6 +38,7 @@ const sections = (() => {
 })()
 
 module.exports = {
+  require: ['./styleguide/register.js'],
   styleguideDir: 'docs',
   pagePerSection: true,
   ribbon: {

--- a/styleguide/register.js
+++ b/styleguide/register.js
@@ -1,0 +1,4 @@
+import Vue from 'vue'
+import VImg from '../src'
+
+Vue.use(VImg)


### PR DESCRIPTION
## Why

上个版本没带 `background-image` 玩，通过实践发现使用 `background-image` 的场景还是挺多，需要这个功能

## How

![image](https://user-images.githubusercontent.com/21327913/68832203-4ef54700-06eb-11ea-9299-6d310439e61d.png)

## Test
在某个项目中回归测试

## Attention
第一次使用可能出现因组件未判断浏览器是否支持`webp`而直接判定为`false`，导致前若干个图片无法享受到`webp`功能

## Docs
- directive.md
