### PR TITLE
docs: 修正协议

### DIFF
--- a/docs/basic.md
+++ b/docs/basic.md
@@ -25,8 +25,8 @@ export default {
       height: '500px',
       i: 0,
       srcs: [
-        'http://image-demo.oss-cn-hangzhou.aliyuncs.com/panda.png',
-        'http://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg',
+        'https://image-demo.oss-cn-hangzhou.aliyuncs.com/panda.png',
+        'https://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg',
       ]
     }
   }

--- a/docs/directive.md
+++ b/docs/directive.md
@@ -9,14 +9,14 @@ use `v-img` directive, can let background-image to use webp。
 
 ```vue
 <template>
-  <div v-img="{src}" style="width:200px;height:200px" />
+  <div v-img="{src}" style="width:100px;height:100px;background-repeat:no-repeat;" />
 </template>
 
 <script>
 export default {
   data() {
     return {
-      src: 'http://image-demo.oss-cn-hangzhou.aliyuncs.com/panda.png'
+      src: 'https://image-demo.oss-cn-hangzhou.aliyuncs.com/panda.png'
     }
   }
 }

--- a/docs/extra-query.md
+++ b/docs/extra-query.md
@@ -17,7 +17,7 @@ This example shows using alibaba image service to process images.
 export default {
   data() {
     return {
-      src: 'http://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg'
+      src: 'https://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg'
     }
   }
 }


### PR DESCRIPTION
## Why
示例图片地址都是`http`

## How
`http` -> `https`

原因：仅`//`会报错..