### PR TITLE
feat: alioss 图片资源支持 自动剪裁

### DIFF
--- a/docs/autocrop.md
+++ b/docs/autocrop.md
@@ -5,13 +5,25 @@
 <template>
   <div>
     <p> 原图 宽：400 高：267 </p>
-    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg"/>
+    <v-img :src="src"/>
     <p> 按宽度等比缩放 宽：100 高：等比缩放<p/>
-    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg" width="100"/>
+    <v-img :src="src" width="100"/>
     <p> 按高度等比缩放 高：100 宽：等比缩放<p/>
-    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg" height="100"/>
+    <v-img :src="src" height="100"/>
     <p> 固定宽高剪裁，宽高：100，居中裁剪，不拉伸图片 </p>
-    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg" height="100" width="100"/>
+    <v-img :src="src" height="100" width="100"/>
+    <p> 对背景图片使用自动裁剪 </p>
+    <div v-img="{src}" style="width:100px;height:100px;background-repeat:no-repeat;background-size: 100% auto"></div>
   </div>
 </template>
+
+<script>
+export default {
+  data() {
+    return {
+      src: 'https://image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg'
+    }
+  }
+}
+</script>
 ```

--- a/docs/autocrop.md
+++ b/docs/autocrop.md
@@ -1,0 +1,17 @@
+## 自动裁剪
+如果传入 width 或 height 属性，会默认按照客户端的 devicePixelRatio（默认是 2） 获取合适大小的图片。节省流量的同时，保证图片最佳显示效果
+
+```vue
+<template>
+  <div>
+    <p> 原图 宽：400 高：267 </p>
+    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg"/>
+    <p> 按宽度等比缩放 宽：100 高：等比缩放<p/>
+    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg" width="100"/>
+    <p> 按高度等比缩放 高：100 宽：等比缩放<p/>
+    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg" height="100"/>
+    <p> 固定宽高剪裁，宽高：100，居中裁剪，不拉伸图片 </p>
+    <v-img src="//image-demo.oss-cn-hangzhou.aliyuncs.com/example.jpg" height="100" width="100"/>
+  </div>
+</template>
+```

--- a/src/background.js
+++ b/src/background.js
@@ -4,22 +4,36 @@ import getImageSrc from './provider-config'
 function getSrc(config) {
   const isSupportWebp =
     JSON.parse(localStorage.getItem('isSupportWebp')) || false
-  const {provider = 'alibaba', extraQuery, src} = config
+  const {
+    provider = 'alibaba',
+    extraQuery,
+    src,
+    width,
+    height,
+    autocrop = true
+  } = config
   if (!src) {
     return
   }
 
   return getImageSrc({
+    autocrop,
     provider,
     src,
     isSupportWebp,
-    extraQuery
+    extraQuery,
+    width,
+    height
   })
 }
 
 export default {
   init(el, {value = {}}) {
-    const src = getSrc(value)
+    const size = {
+      width: el.offsetWidth,
+      height: el.offsetHeight
+    }
+    const src = getSrc({...size, ...value})
     el.classList.add('lazyload')
     el.setAttribute('data-bgset', src)
   },

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 import 'lazysizes/plugins/bgset/ls.bgset'
-import providerConf from './provider-config'
+import getImageSrc from './provider-config'
 
 function getSrc(config) {
   const isSupportWebp =
@@ -9,7 +9,8 @@ function getSrc(config) {
     return
   }
 
-  return providerConf[provider].getSrc({
+  return getImageSrc({
+    provider,
     src,
     isSupportWebp,
     extraQuery

--- a/src/provider-config.js
+++ b/src/provider-config.js
@@ -31,7 +31,7 @@ export const providerConfig = {
       if (isSupportWebp && is([png, jpg], src)) query += '/format,webp'
       /**
        * 质量变换仅对jpg、webp有效。（png已被转为webp）
-       * @see https://+\dhelp.aliyun.com/document_detail/44705.html?spm=a2c4g.11186623.6.1256.347d69cb9tB4ZR
+       * @see https://help.aliyun.com/document_detail/44705.html?spm=a2c4g.11186623.6.1256.347d69cb9tB4ZR
        */
       if (is([png, jpg, webp], src)) query += '/quality,Q_75'
 

--- a/src/provider-config.js
+++ b/src/provider-config.js
@@ -140,6 +140,7 @@ export const providerConfig = {
 }
 
 export default vm => {
+  vm.$src = ''
   const providerPipe = providerConfig[vm.provider]
   const output = pipe([
     providerPipe[process.CONVERT_WEBP],

--- a/src/provider-config.js
+++ b/src/provider-config.js
@@ -31,7 +31,7 @@ export const providerConfig = {
       if (isSupportWebp && is([png, jpg], src)) query += '/format,webp'
       /**
        * 质量变换仅对jpg、webp有效。（png已被转为webp）
-       * @see https://help.aliyun.com/document_detail/44705.html?spm=a2c4g.11186623.6.1256.347d69cb9tB4ZR
+       * @see https://+\dhelp.aliyun.com/document_detail/44705.html?spm=a2c4g.11186623.6.1256.347d69cb9tB4ZR
        */
       if (is([png, jpg, webp], src)) query += '/quality,Q_75'
 
@@ -39,10 +39,42 @@ export const providerConfig = {
       return vm
     },
 
-    // [process.CROP_IMAGE](vm) {
-    //   const dpr = (window && window.devicePixelRatio) || 2
-    //   const actions = ['/resize']
-    // },
+    [process.CROP_IMAGE](vm) {
+      const {$src = '', width, height, autocrop, src} = vm
+
+      if (!autocrop || is(svg, src)) return vm
+      const DPR = 2
+      let dpr = (window && window.devicePixelRatio) || DPR
+      if (dpr === 1) {
+        dpr = DPR
+      }
+      const actions = ['/resize']
+      const WIDTH = `w_${width * dpr}`
+      const HEIGHT = `h_${height * dpr}`
+      const AUTOCROP = `m_fill`
+
+      if (isNaN(width) && isNaN(height)) {
+        return vm
+      }
+
+      if (!isNaN(width) && !isNaN(height)) {
+        actions.push(AUTOCROP)
+      }
+
+      if (!isNaN(height)) {
+        actions.push(HEIGHT)
+      }
+
+      if (!isNaN(width)) {
+        actions.push(WIDTH)
+      }
+
+      const resizeQuery = actions.join(',')
+
+      vm.$src = resizeQuery + $src
+
+      return vm
+    },
 
     [process.APPEND_QUERY](vm) {
       const {src, extraQuery} = vm

--- a/src/provider-config.js
+++ b/src/provider-config.js
@@ -42,7 +42,7 @@ export const providerConfig = {
     [process.CROP_IMAGE](vm) {
       const {$src = '', width, height, autocrop, src} = vm
 
-      if (!autocrop || is(svg, src)) return vm
+      if (!autocrop || is(svg, src) || !src) return vm
       const DPR = 2
       let dpr = (window && window.devicePixelRatio) || DPR
       if (dpr === 1) {

--- a/src/provider-config.js
+++ b/src/provider-config.js
@@ -6,7 +6,7 @@ function is(types, src) {
   return Array.isArray(types) ? types.some(t => t.test(src)) : types.test(src)
 }
 
-const process = {
+const srcProcess = {
   CONVERT_WEBP: 'convertWebp',
   CROP_IMAGE: 'cropImage',
   APPEND_QUERY: 'appendQuery'
@@ -25,7 +25,7 @@ const pipe = function(fns) {
 
 export const providerConfig = {
   alibaba: {
-    [process.CONVERT_WEBP](vm) {
+    [srcProcess.CONVERT_WEBP](vm) {
       const {src, isSupportWebp} = vm
       let query = vm.$src || ''
       if (isSupportWebp && is([png, jpg], src)) query += '/format,webp'
@@ -39,7 +39,7 @@ export const providerConfig = {
       return vm
     },
 
-    [process.CROP_IMAGE](vm) {
+    [srcProcess.CROP_IMAGE](vm) {
       const {$src = '', width, height, autocrop, src} = vm
 
       if (!autocrop || is(svg, src) || !src) return vm
@@ -76,7 +76,7 @@ export const providerConfig = {
       return vm
     },
 
-    [process.APPEND_QUERY](vm) {
+    [srcProcess.APPEND_QUERY](vm) {
       const {src, extraQuery} = vm
       let query = vm.$src || ''
       if (extraQuery) query += '/' + extraQuery
@@ -93,7 +93,7 @@ export const providerConfig = {
     }
   },
   qiniu: {
-    [process.CONVERT_WEBP](vm) {
+    [srcProcess.CONVERT_WEBP](vm) {
       const {src, isSupportWebp} = vm
       let query = vm.$src || ''
       // imageMogr2 接口可支持处理的原图片格式有 psd、jpeg、png、gif、webp、tiff、bmp
@@ -107,7 +107,7 @@ export const providerConfig = {
       return vm
     },
 
-    [process.APPEND_QUERY](vm) {
+    [srcProcess.APPEND_QUERY](vm) {
       const {src, extraQuery} = vm
       let query = vm.$src || ''
       if (extraQuery) query += '/' + extraQuery
@@ -120,7 +120,7 @@ export const providerConfig = {
     }
   },
   self: {
-    [process.CONVERT_WEBP](vm) {
+    [srcProcess.CONVERT_WEBP](vm) {
       const {src, isSupportWebp} = vm
       if (isSupportWebp && is([png, jpg], src)) {
         vm.$src =
@@ -132,7 +132,7 @@ export const providerConfig = {
     }
   },
   none: {
-    [process.CONVERT_WEBP](vm) {
+    [srcProcess.CONVERT_WEBP](vm) {
       vm.$src = vm.src
       return vm
     }
@@ -143,9 +143,9 @@ export default vm => {
   vm.$src = ''
   const providerPipe = providerConfig[vm.provider]
   const output = pipe([
-    providerPipe[process.CONVERT_WEBP],
-    providerPipe[process.CROP_IMAGE],
-    providerPipe[process.APPEND_QUERY]
+    providerPipe[srcProcess.CONVERT_WEBP],
+    providerPipe[srcProcess.CROP_IMAGE],
+    providerPipe[srcProcess.APPEND_QUERY]
   ])(vm)
   return output.$src
 }

--- a/src/v-img.vue
+++ b/src/v-img.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import providerConfig from './provider-config'
+import {providerConfig, default as getSrc} from './provider-config'
 
 /**
  * TODO:
@@ -92,6 +92,14 @@ export default {
     error: {
       type: String,
       default: ''
+    },
+
+    /**
+     * 是否开启自动裁剪
+     */
+    autocrop: {
+      type: Boolean,
+      default: true
     }
   },
 
@@ -142,7 +150,7 @@ export default {
       }
     },
     imageSrc() {
-      return providerConfig[this.provider].getSrc(this)
+      return getSrc(this)
     },
     loadingImage() {
       return this.placeholder || this.$vImg.placeholder

--- a/test/provider-config.test.js
+++ b/test/provider-config.test.js
@@ -1,11 +1,11 @@
-import config from '../src/provider-config'
+import getSrc from '../src/provider-config'
 
 describe('alibaba', () => {
-  const {getSrc} = config.alibaba
   const src = 'http://image-demo.oss-cn-hangzhou.aliyuncs.com/panda.png'
   test('浏览器支持webp', () => {
     expect(
       getSrc({
+        provider: 'alibaba',
         src,
         isSupportWebp: true
       })
@@ -14,6 +14,7 @@ describe('alibaba', () => {
   test('浏览器不支持webp', () => {
     expect(
       getSrc({
+        provider: 'alibaba',
         src,
         isSupportWebp: false
       })
@@ -23,6 +24,7 @@ describe('alibaba', () => {
     const webp = src.replace('png', 'webp')
     expect(
       getSrc({
+        provider: 'alibaba',
         src: webp,
         isSupportWebp: true
       })
@@ -31,9 +33,10 @@ describe('alibaba', () => {
   test('svg不处理，除非有extraQuery', () => {
     const svg = src.replace('png', 'svg')
     const extraQuery = 'rotate,10'
-    expect(getSrc({src: svg})).toBe(svg)
+    expect(getSrc({provider: 'alibaba', src: svg})).toBe(svg)
     expect(
       getSrc({
+        provider: 'alibaba',
         src: svg,
         extraQuery
       })
@@ -43,6 +46,7 @@ describe('alibaba', () => {
     const extraQuery = 'rotate,10'
     expect(
       getSrc({
+        provider: 'alibaba',
         src,
         isSupportWebp: true,
         extraQuery
@@ -52,11 +56,11 @@ describe('alibaba', () => {
 })
 
 describe('qiniu', () => {
-  const {getSrc} = config.qiniu
   const src = 'https://odum9helk.qnssl.com/resource/gogopher.jpg'
   test('浏览器支持webp', () => {
     expect(
       getSrc({
+        provider: 'qiniu',
         src,
         isSupportWebp: true
       })
@@ -65,6 +69,7 @@ describe('qiniu', () => {
   test('浏览器不支持webp', () => {
     expect(
       getSrc({
+        provider: 'qiniu',
         src,
         isSupportWebp: false
       })
@@ -74,6 +79,7 @@ describe('qiniu', () => {
     const webp = src.replace('jpg', 'webp')
     expect(
       getSrc({
+        provider: 'qiniu',
         src: webp,
         isSupportWebp: true
       })
@@ -81,12 +87,13 @@ describe('qiniu', () => {
   })
   test('svg不处理', () => {
     const svg = src.replace('jpg', 'svg')
-    expect(getSrc({src: svg})).toBe(svg)
+    expect(getSrc({provider: 'qiniu', src: svg})).toBe(svg)
   })
   test('带extraQuery的情况', () => {
     const extraQuery = 'rotate/10'
     expect(
       getSrc({
+        provider: 'qiniu',
         src,
         isSupportWebp: true,
         extraQuery
@@ -99,7 +106,8 @@ describe('self', () => {
   test('精确的资源路径', () => {
     const src = 'https://cumming.com/creampie.png'
     expect(
-      config.self.getSrc({
+      getSrc({
+        provider: 'self',
         src,
         isSupportWebp: true
       })
@@ -110,7 +118,8 @@ describe('self', () => {
     const src = 'https://cumming.com/creampie.png'
     const query = '?format/jpeg'
     expect(
-      config.self.getSrc({
+      getSrc({
+        provider: 'self',
         src: src + query,
         isSupportWebp: true
       })
@@ -120,7 +129,8 @@ describe('self', () => {
   test('资源路径存在相同后缀名', () => {
     const src = 'https://cumming.com/creampie.png.creampie.png'
     expect(
-      config.self.getSrc({
+      getSrc({
+        provider: 'self',
         src,
         isSupportWebp: true
       })
@@ -130,7 +140,8 @@ describe('self', () => {
   test('使用本地资源路径', () => {
     const src = './com/creampie.png.creampie.png'
     expect(
-      config.self.getSrc({
+      getSrc({
+        provider: 'self',
         src,
         isSupportWebp: true
       })
@@ -140,7 +151,8 @@ describe('self', () => {
   test('默认情况下不转换svg', () => {
     const src = './com/creampie.png.creampie.svg'
     expect(
-      config.self.getSrc({
+      getSrc({
+        provider: 'self',
         src,
         isSupportWebp: true
       })

--- a/test/provider-config.test.js
+++ b/test/provider-config.test.js
@@ -53,6 +53,53 @@ describe('alibaba', () => {
       })
     ).toBe(`${src}?x-oss-process=image/format,webp/quality,Q_75/${extraQuery}`)
   })
+
+  test('自动裁剪，只传 width', () => {
+    expect(
+      getSrc({
+        provider: 'alibaba',
+        src,
+        isSupportWebp: true,
+        autocrop: true,
+        width: 100
+      })
+    ).toBe(`${src}?x-oss-process=image/resize,w_200/format,webp/quality,Q_75`)
+  })
+  test('自动裁剪，只传 height', () => {
+    expect(
+      getSrc({
+        provider: 'alibaba',
+        src,
+        isSupportWebp: true,
+        autocrop: true,
+        height: 100
+      })
+    ).toBe(`${src}?x-oss-process=image/resize,h_200/format,webp/quality,Q_75`)
+  })
+  test('自动裁剪，height 和 width 都传', () => {
+    expect(
+      getSrc({
+        provider: 'alibaba',
+        src,
+        isSupportWebp: true,
+        autocrop: true,
+        height: 100,
+        width: 100
+      })
+    ).toBe(
+      `${src}?x-oss-process=image/resize,m_fill,h_200,w_200/format,webp/quality,Q_75`
+    )
+  })
+  test('自动裁剪，height 和 width 都不传', () => {
+    expect(
+      getSrc({
+        provider: 'alibaba',
+        src,
+        isSupportWebp: true,
+        autocrop: true
+      })
+    ).toBe(`${src}?x-oss-process=image/format,webp/quality,Q_75`)
+  })
 })
 
 describe('qiniu', () => {


### PR DESCRIPTION
## Why
通过一下预设和图片服务，可以按实际情况加载合适大小的图片，节省流量的同时，不影响显示效果

## How
暂时实现的 alioss 的自动剪裁
通过重构，将 src 的处理，以 pipe 的方式处理，方便后续增加处理步骤
通过 alioss 的图片服务和属性中的 width 或 height 进行图片自动剪裁

## Test
增加了四个自动剪裁的测试用例

### Demo
![image](https://user-images.githubusercontent.com/27187946/72702467-c339e400-3b8d-11ea-9b10-451ad71c82a5.png)

按照 dpr 2 的一般情况去加载图片。
![image](https://user-images.githubusercontent.com/27187946/72702483-d3ea5a00-3b8d-11ea-8fd4-f538cb788852.png)


## Docs
新增自动剪裁文档
