### PR TITLE
fix(provider-config): 更正常量名

### DIFF
--- a/src/provider-config.js
+++ b/src/provider-config.js
@@ -73,7 +73,7 @@ export const providerConfig = {
       const resizeQuery = actions.join(',')
 
       vm.$src = resizeQuery + $src
-      vm.$config.resizeQuery = resizeQuery
+      vm.$resizeQuery = resizeQuery
 
       return vm
     },
@@ -143,13 +143,12 @@ export const providerConfig = {
 
 export default vm => {
   vm.$src = ''
-  vm.$config = {}
   const providerPipe = providerConfig[vm.provider]
   const output = pipe([
     providerPipe[srcProcess.CONVERT_WEBP],
     providerPipe[srcProcess.CROP_IMAGE],
     providerPipe[srcProcess.APPEND_QUERY]
   ])(vm)
-  vm.$uncroppedSrc = vm.$src.replace(vm.$config.resizeQuery, '')
+  vm.$uncroppedSrc = vm.$src.replace(vm.$resizeQuery, '')
   return output
 }


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why

`Vue.prototype.$config` 被 `vm.$config = {}` 覆盖

## How

1. 移除 `$config`, 避免与 `Vue.prototype.$config` 冲突
	1.1 `vm.$config.resizeQuery -> vm.$resizeQuery`

## Test

无前后差异

![image](https://user-images.githubusercontent.com/19513289/98631339-2d5b8980-2358-11eb-889c-692024a8615b.png)

<details><summary>奇怪吧</summary>

![image](https://user-images.githubusercontent.com/19513289/98631400-50863900-2358-11eb-9180-803288d02678.png)

</details>