### PR TITLE
fix: 兼容传 src 为 null 的情况

### DIFF
--- a/test/provider-config.test.js
+++ b/test/provider-config.test.js
@@ -116,6 +116,22 @@ describe('alibaba', () => {
       })
     ).toBe(`${src}?x-oss-process=image/format,webp/quality,Q_75`)
   })
+
+  test('测试 src 为空', () => {
+    expect(
+      getSrc({
+        provider: 'alibaba',
+        src: ''
+      })
+    ).toBe('')
+
+    expect(
+      getSrc({
+        provider: 'alibaba',
+        src: null
+      })
+    ).toBe('')
+  })
 })
 
 describe('qiniu', () => {


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
当 src 为 null 时，调用 vm.$uncroppedSrc = vm.$src.replace(vm.$resizeQuery, '') 报错了
![image](https://user-images.githubusercontent.com/9384365/100437857-5c098c00-30dc-11eb-8c60-58b091781217.png)


## How
当 src 为 null 时，直接返回
## Test
![image](https://user-images.githubusercontent.com/9384365/100437752-2fee0b00-30dc-11eb-8126-e36c949cc2c1.png)


## Docs

