### PR TITLE
feat: compute layout

### DIFF
--- a/src/compute-layout.js
+++ b/src/compute-layout.js
@@ -1,0 +1,38 @@
+/**
+ * Created by levy on 2021/1/13.
+ */
+function isPixel(dimension) {
+  return ('' + dimension).indexOf('px') > -1
+}
+export default function(vm) {
+  let width, height
+  if (Number.isInteger(vm.width) || isPixel(vm.width))
+    width = parseInt(vm.width)
+  if (Number.isInteger(vm.height) || isPixel(vm.height))
+    height = parseInt(vm.height)
+
+  if (!isNaN(width) && !isNaN(height)) return {width, height}
+
+  if (isNaN(width) && vm.$el) {
+    let styleWidth = window.getComputedStyle(vm.$el).width
+
+    if (styleWidth.indexOf('px') > -1) width = parseInt(styleWidth)
+    else {
+      width = (height * vm.$el.naturalWidth) / vm.$el.naturalHeight
+    }
+  }
+  if (isNaN(height) && vm.$el) {
+    let styleHeight = window.getComputedStyle(vm.$el).height
+
+    if (styleHeight.indexOf('px') > -1) height = parseInt(styleHeight)
+    else {
+      height = (width * vm.$el.naturalHeight) / vm.$el.naturalWidth
+    }
+  }
+
+  let result = {}
+  if (width > 0) result.width = width
+  if (height > 0) result.height = height
+
+  return result
+}

--- a/src/compute-layout.js
+++ b/src/compute-layout.js
@@ -4,6 +4,7 @@
 function isPixel(dimension) {
   return ('' + dimension).indexOf('px') > -1
 }
+
 export default function(vm) {
   let width, height
   if (Number.isInteger(vm.width) || isPixel(vm.width))
@@ -11,28 +12,31 @@ export default function(vm) {
   if (Number.isInteger(vm.height) || isPixel(vm.height))
     height = parseInt(vm.height)
 
-  if (!isNaN(width) && !isNaN(height)) return {width, height}
-
   if (isNaN(width) && vm.$el) {
     let styleWidth = window.getComputedStyle(vm.$el).width
-
-    if (styleWidth.indexOf('px') > -1) width = parseInt(styleWidth)
-    else {
-      width = (height * vm.$el.naturalWidth) / vm.$el.naturalHeight
-    }
+    if (isPixel(styleWidth)) width = parseInt(styleWidth)
   }
   if (isNaN(height) && vm.$el) {
     let styleHeight = window.getComputedStyle(vm.$el).height
-
-    if (styleHeight.indexOf('px') > -1) height = parseInt(styleHeight)
-    else {
-      height = (width * vm.$el.naturalHeight) / vm.$el.naturalWidth
-    }
+    if (isPixel(styleHeight)) height = parseInt(styleHeight)
   }
 
-  let result = {}
-  if (width > 0) result.width = width
-  if (height > 0) result.height = height
+  // TODO 这里假设 auto 没有返回数值，待验证
+  if ((isNaN(width) && isNaN(height)) || (!width && !height)) return {}
 
-  return result
+  let naturalWidth = vm.$el.naturalWidth,
+    naturalHeight = vm.$el.naturalHeight
+
+  if (width > naturalWidth) width = naturalWidth
+  if (height > naturalHeight) height = naturalHeight
+
+  // getComputedStyle 有可能会返回 natural[Width/Height]，这使得其返回值不可直接使用，还需要最后 resize 一下。
+  let scaleWidth = (height * vm.$el.naturalWidth) / vm.$el.naturalHeight
+  let scaleHeight = (width * vm.$el.naturalHeight) / vm.$el.naturalWidth
+
+  if (!scaleWidth || width * scaleHeight <= height * scaleWidth)
+    return {width, height: scaleHeight}
+  else if (!scaleHeight || scaleWidth * height <= scaleHeight * width)
+    return {width: scaleWidth, height}
+  return {}
 }

--- a/src/directive.js
+++ b/src/directive.js
@@ -13,7 +13,8 @@ function getSrc(config) {
     src,
     width,
     height,
-    autocrop = true
+    autocrop = true,
+    preferHttps = true,
   } = config
   if (!src) {
     return
@@ -26,7 +27,8 @@ function getSrc(config) {
     isSupportWebp,
     extraQuery,
     width,
-    height
+    height,
+    preferHttps,
   }).$src
 }
 
@@ -34,7 +36,7 @@ export default {
   init(el, {value = {}}) {
     const size = {
       width: el.offsetWidth,
-      height: el.offsetHeight
+      height: el.offsetHeight,
     }
     const src = getSrc({...size, ...value})
     el.classList.add('lazyload')
@@ -44,5 +46,5 @@ export default {
   update(el, {value = {}}) {
     const src = getSrc(value)
     el.style.backgroundImage = `url(${src})`
-  }
+  },
 }

--- a/src/v-img.vue
+++ b/src/v-img.vue
@@ -20,6 +20,7 @@
 <script>
 import {providerConfig, default as getSrc} from './provider-config'
 import ua from './ua'
+import computeLayout from './compute-layout'
 
 /**
  * TODO:
@@ -137,6 +138,8 @@ export default {
         backgroundRepeat: 'no-repeat',
         backgroundColor: '#f0f2f5',
       }
+      let layout = {}
+
       switch (this.status) {
         case STATUS_IDLE:
           if (!this.hasLoading) return {}
@@ -152,8 +155,11 @@ export default {
             backgroundSize: 'auto 40px',
             cursor: 'pointer',
           }
+        // loaded
         default:
-          return {}
+          layout = computeLayout(this)
+          Object.keys(layout).forEach(k => (layout[k] = layout[k] + 'px'))
+          return layout
       }
     },
     imageSrc() {

--- a/src/v-img.vue
+++ b/src/v-img.vue
@@ -40,7 +40,8 @@ const STATUS_ERROR = 3
 
 export default {
   name: 'VImg',
-
+  // TODO: 这里新增一个属性，如果想指令也可以使用，需要在 directive.js 里读取，暂时不能只修改一个处，就同时在两个文件生效
+  // 因为这个的限制 https://github.com/vue-styleguidist/vue-styleguidist/issues/923
   props: {
     /** 图片地址 */
     src: {

--- a/test/compute-layout.spec.js
+++ b/test/compute-layout.spec.js
@@ -5,14 +5,15 @@ import computeLayout from '../src/compute-layout'
 describe('compute img layout', () => {
   let vm
   let expected
+  let natural
 
   beforeEach(() => {
     vm = {
       width: '', // 理想值是数字
       height: '', // 理想值是数字
       $el: {
-        naturalWidth: '', // 数字
-        naturalHeight: '', // 数字
+        naturalWidth: 200,
+        naturalHeight: 200,
         style: {
           width: '', // 可能是 auto, 可能是 100%，可能是 300px 或其他单位。。。
           height: '',
@@ -20,6 +21,21 @@ describe('compute img layout', () => {
       },
     }
     expected = {width: 100, height: 100}
+    natural = {width: 200, height: 200}
+  })
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle#notes
+  // width, height, they are the same as used values
+  Object.defineProperty(window, 'getComputedStyle', {
+    value: jest.fn(el => {
+      let width = el.style.width || el.naturalWidth
+      let height = el.style.height || el.naturalHeight
+
+      return {
+        width: Number.isInteger(width) ? width + 'px' : width,
+        height: Number.isInteger(height) ? height + 'px' : height,
+      }
+    }),
   })
 
   // 此时优先使用 width
@@ -49,26 +65,15 @@ describe('compute img layout', () => {
 
   test('width 有数值，height/style.height 无值, height 自动计算', () => {
     vm.width = 100
-    vm.$el.naturalWidth = 200
-    vm.$el.naturalHeight = 200
     expect(computeLayout(vm)).toStrictEqual(expected)
   })
 
   test('style.width 有px值，height/style.height 无值, height 自动计算', () => {
     vm.$el.style.width = '100px'
-    vm.$el.naturalWidth = 200
-    vm.$el.naturalHeight = 200
     expect(computeLayout(vm)).toStrictEqual(expected)
   })
 
   test('只有 naturalWidth/naturalHeight', () => {
-    Object.defineProperty(window, 'getComputedStyle', {
-      value: jest.fn(el => ({
-        width: el.naturalWidth + 'px',
-        height: el.naturalHeight + 'px',
-      })),
-    })
-
     vm.$el.naturalWidth = 100
     vm.$el.naturalHeight = 100
     expect(computeLayout(vm)).toStrictEqual(expected)
@@ -77,15 +82,41 @@ describe('compute img layout', () => {
   test('width/height 不是纯数字, 暂不支持', () => {
     vm.width = '100%'
     vm.height = 'auto'
-    expect(computeLayout(vm)).toStrictEqual({})
+    expect(computeLayout(vm)).toStrictEqual(natural)
   })
 
   test('style.width/style.height 不是px，暂不支持', () => {
     vm.$el.style.width = 'auto'
     vm.$el.style.height = '100%'
     expect(computeLayout(vm)).toStrictEqual({})
+  })
 
-    vm.$el.style.width = '10em'
+  test('width/height 设置为 0, 忽略不计', () => {
+    vm.width = 0
+    vm.height = 0
     expect(computeLayout(vm)).toStrictEqual({})
+
+    vm.width = ''
+    vm.height = ''
+    vm.$el.style.width = '0'
+    vm.$el.style.height = '0'
+    expect(computeLayout(vm)).toStrictEqual({})
+  })
+
+  test('设置了不恰当比例的宽高，要防止变形', () => {
+    vm.$el.style.width = '80px'
+    vm.$el.style.height = '100px'
+    expect(computeLayout(vm)).toStrictEqual({width: 80, height: 80})
+
+    vm.width = 100
+    vm.height = 150
+    expect(computeLayout(vm)).toStrictEqual(expected)
+
+    vm.width = 300
+    vm.height = 300
+    expect(computeLayout(vm)).toStrictEqual(natural)
+
+    vm.width = 100
+    expect(computeLayout(vm)).toStrictEqual(expected)
   })
 })

--- a/test/compute-layout.spec.js
+++ b/test/compute-layout.spec.js
@@ -104,8 +104,8 @@ describe('compute img layout', () => {
   })
 
   test('设置了不恰当比例的宽高，要防止变形', () => {
-    vm.$el.style.width = '80px'
-    vm.$el.style.height = '100px'
+    vm.$el.style.width = '100px'
+    vm.$el.style.height = '80px'
     expect(computeLayout(vm)).toStrictEqual({width: 80, height: 80})
 
     vm.width = 100

--- a/test/compute-layout.spec.js
+++ b/test/compute-layout.spec.js
@@ -1,0 +1,91 @@
+/**
+ * Created by levy on 2021/1/13.
+ */
+import computeLayout from '../src/compute-layout'
+describe('compute img layout', () => {
+  let vm
+  let expected
+
+  beforeEach(() => {
+    vm = {
+      width: '', // 理想值是数字
+      height: '', // 理想值是数字
+      $el: {
+        naturalWidth: '', // 数字
+        naturalHeight: '', // 数字
+        style: {
+          width: '', // 可能是 auto, 可能是 100%，可能是 300px 或其他单位。。。
+          height: '',
+        },
+      },
+    }
+    expected = {width: 100, height: 100}
+  })
+
+  // 此时优先使用 width
+  test('width/height 有数值, style.width/style.height 有px值', () => {
+    vm.width = 100
+    vm.height = 100
+    vm.$el.style.width = '50px'
+    vm.$el.style.height = '50px'
+    expect(computeLayout(vm)).toStrictEqual(expected)
+  })
+
+  test('width/height 有数值', () => {
+    vm.width = 100
+    vm.height = 100
+    expect(computeLayout(vm)).toStrictEqual(expected)
+
+    // 兼容处理不正确的输入值
+    vm.width = '100px'
+    expect(computeLayout(vm)).toStrictEqual(expected)
+  })
+
+  test('width/height 无数值，style.width/style.height 有px值', () => {
+    vm.$el.style.width = '100px'
+    vm.$el.style.height = '100px'
+    expect(computeLayout(vm)).toStrictEqual(expected)
+  })
+
+  test('width 有数值，height/style.height 无值, height 自动计算', () => {
+    vm.width = 100
+    vm.$el.naturalWidth = 200
+    vm.$el.naturalHeight = 200
+    expect(computeLayout(vm)).toStrictEqual(expected)
+  })
+
+  test('style.width 有px值，height/style.height 无值, height 自动计算', () => {
+    vm.$el.style.width = '100px'
+    vm.$el.naturalWidth = 200
+    vm.$el.naturalHeight = 200
+    expect(computeLayout(vm)).toStrictEqual(expected)
+  })
+
+  test('只有 naturalWidth/naturalHeight', () => {
+    Object.defineProperty(window, 'getComputedStyle', {
+      value: jest.fn(el => ({
+        width: el.naturalWidth + 'px',
+        height: el.naturalHeight + 'px',
+      })),
+    })
+
+    vm.$el.naturalWidth = 100
+    vm.$el.naturalHeight = 100
+    expect(computeLayout(vm)).toStrictEqual(expected)
+  })
+
+  test('width/height 不是纯数字, 暂不支持', () => {
+    vm.width = '100%'
+    vm.height = 'auto'
+    expect(computeLayout(vm)).toStrictEqual({})
+  })
+
+  test('style.width/style.height 不是px，暂不支持', () => {
+    vm.$el.style.width = 'auto'
+    vm.$el.style.height = '100%'
+    expect(computeLayout(vm)).toStrictEqual({})
+
+    vm.$el.style.width = '10em'
+    expect(computeLayout(vm)).toStrictEqual({})
+  })
+})


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
只设置图片 宽/高时，“聪明点”的浏览器能自动计算缺省的 高/宽 值，但有些浏览器不会，如 iOS Safari 13.3 就会把图片原始值作为缺省值，导致图片变形。

directive.js 修复的是上个 PR 的bug #39 

## How
解析输入的宽高，并根据原始宽高，进行等比例设置 style

> 目前主要针对 px 值的计算

## Test
yes
